### PR TITLE
added support for a jsx option

### DIFF
--- a/lib/fat-arrow-same-line.js
+++ b/lib/fat-arrow-same-line.js
@@ -66,7 +66,7 @@ module.exports = function (context) {
         || (allowNew && bodyType === 'NewExpression')
         || (allowTemplates && (bodyType === 'TemplateLiteral' || bodyType === 'TaggedTemplateExpression'))
         || memberIsAllowed
-        || (allowJSX && bodyType === 'JSXElement')
+        || (allowJSX && [ 'JSXElement', 'JSXFragment' ].includes(bodyType))
       )
     ) {
       if (bodyStartLine > arrowLine || bodyEndLine > arrowLine) {

--- a/lib/fat-arrow-same-line.js
+++ b/lib/fat-arrow-same-line.js
@@ -8,6 +8,7 @@ module.exports = function (context) {
   let allowNew = false;
   let allowTemplates = false;
   let allowMembers = false;
+  let allowJSX = false;
 
   if (context.options.length) {
     allowParens = context.options[0].allowParens;
@@ -17,6 +18,7 @@ module.exports = function (context) {
     allowNew = context.options[0].allowNew;
     allowTemplates = context.options[0].allowTemplates;
     allowMembers = context.options[0].allowMembers;
+    allowJSX = context.options[0].allowJSX;
   }
 
   const addendumMessages = [];
@@ -27,6 +29,7 @@ module.exports = function (context) {
   if (allowNew) addendumMessages.push('new statements');
   if (allowTemplates) addendumMessages.push('template strings');
   if (allowMembers) addendumMessages.push('whitelisted member functions');
+  if (allowJSX) addendumMessages.push('JSX');
 
   const standardMessage = `arrow functions with implicit returns must start and end on the same line (except ${addendumMessages.join(', ')})`;
 
@@ -42,7 +45,7 @@ module.exports = function (context) {
 
     let memberIsAllowed = false;
 
-    if (!allowParens && bodyType !== 'ObjectExpression' && node.body.extra && node.body.extra.parenthesized) {
+    if (!allowJSX && (!allowParens && bodyType !== 'ObjectExpression' && node.body.extra && node.body.extra.parenthesized)) {
       reportError(node.body, 'arrow functions with implicit returns must not have parenthesized statements');
     }
 
@@ -63,6 +66,7 @@ module.exports = function (context) {
         || (allowNew && bodyType === 'NewExpression')
         || (allowTemplates && (bodyType === 'TemplateLiteral' || bodyType === 'TaggedTemplateExpression'))
         || memberIsAllowed
+        || (allowJSX && bodyType === 'JSXElement')
       )
     ) {
       if (bodyStartLine > arrowLine || bodyEndLine > arrowLine) {


### PR DESCRIPTION
I really like using this plugin because it promotes readable code. The standard for React is to have JSXElements wrap multiple lines and almost always in parentheses. This PR adds in support to skip over anything that is JSX. There's no need to add in support for ensuring parens are there since this is an option that can be added via `eslint-plugin-react` under the `react/jsx-wrap-multiline` rule.